### PR TITLE
Full model

### DIFF
--- a/experiment_configs/yin_yang.yaml
+++ b/experiment_configs/yin_yang.yaml
@@ -1,6 +1,6 @@
 dataset: yin_yang
 neuron_params:
-  activation: linear
+  activation: alpha_equaltime
   g_leak: 1.0
   leak: 0.0
   tau_syn: 1.0
@@ -9,12 +9,12 @@ neuron_params:
 network_layout:
   bias_times: [0.9]
   # delay_means : [0.1, 0.1]
-  delay_means: [-2.3, -2.3]
+  # delay_means: [-2.3, -2.3]
   # delay_means: [-10., -10.]
-  # delay_means: [0.0, 0.0]
+  delay_means: [0.0, 0.0]
   # delay_stdevs: [0.01, 0.01]
-  delay_stdevs: [0.5, 0.5]
-  # delay_stdevs: [0.0, 0.0]
+  # delay_stdevs: [0.5, 0.5]
+  delay_stdevs: [0.0, 0.0]
   threshold_means : [1, 1]
   # threshold_stdevs: [0.1, 0.1]
   threshold_stdevs: [0., 0.]
@@ -49,9 +49,9 @@ training_params:
   print_step_percent: 5.0
   resolution: 0.01
   sim_time: 4.0
-  substitute_delay: true
+  substitute_delay: false
   torch_seed: 2000
-  train_delay: true
+  train_delay: false
   train_threshold: false
   training_noise: false
   use_forward_integrator: false

--- a/src/tests/test_spiketime_linear.py
+++ b/src/tests/test_spiketime_linear.py
@@ -103,7 +103,7 @@ class TestSpiketimeLinear(unittest.TestCase):
         device = "cpu"
         output_spikes = torch.tensor([[11./40., 13./40., 1.1], [1./3., 5./8., 3./2.]]) # n_batch x n_out (now only the actual spike times)
         
-        dw, dt, dd, dtheta = get_spiketime_derivative(delayed_input_spikes, input_weights, neuron_params, device, output_spikes, input_delays)
+        dw, dt, dd, dtheta = get_spiketime_derivative(delayed_input_spikes, input_weights, neuron_params, device, output_spikes, input_delays, thresholds)
         dw_solution = torch.tensor([
             [[-output_spikes[0,0]/4., -output_spikes[0,1]/4., -output_spikes[0,2]/1.], 
              [(0.1-output_spikes[0,0])/4., (0.1-output_spikes[0,1])/4., (0.1-output_spikes[0,2])/1.]],
@@ -141,7 +141,7 @@ class TestSpiketimeLinear(unittest.TestCase):
         device = "cpu"
         output_spikes = torch.tensor([[11./40., 13./40., 1.1], [1./3., 5./8., 3./2.]]) # n_batch x n_out (now only the actual spike times)
 
-        dw, dt, dd, dtheta = get_spiketime_derivative(delayed_input_spikes, input_weights, neuron_params, device, output_spikes, input_delays)
+        dw, dt, dd, dtheta = get_spiketime_derivative(delayed_input_spikes, input_weights, neuron_params, device, output_spikes, input_delays, thresholds)
         dw_solution = torch.tensor([
             [[-output_spikes[0,0]/4., -output_spikes[0,1]/4., -output_spikes[0,2]/1.], 
              [(0.1-output_spikes[0,0])/4., (0.1-output_spikes[0,1])/4., (0.1-output_spikes[0,2])/1.]],
@@ -182,7 +182,7 @@ class TestSpiketimeLinear(unittest.TestCase):
             [(1+3*(0+0.1))/3., (1+1*(0+0.05)+3*(0.5+0.2))/4., (1+0*(0+0.3)+1*(0.5+0.5))/1.]
         ]) # n_batch x n_out
 
-        dw, dt, dd, dtheta = get_spiketime_derivative(delayed_input_spikes, input_weights, neuron_params, device, output_spikes, input_delays)
+        dw, dt, dd, dtheta = get_spiketime_derivative(delayed_input_spikes, input_weights, neuron_params, device, output_spikes, input_delays, thresholds)
         dw_solution = torch.tensor([
             [[(0.1-output_spikes[0,0])/4., (0.05-output_spikes[0,1])/4., (0.3-output_spikes[0,2])/1.], 
              [(0.1+0.01-output_spikes[0,0])/4., (0.1+0.2-output_spikes[0,1])/4., (0.1+0.5-output_spikes[0,2])/1.]],
@@ -222,7 +222,7 @@ class TestSpiketimeLinear(unittest.TestCase):
             [(1+3*(0+0.1))/3., (2+1*(0+0.05)+3*(0.5+0.2))/4., (3+0*(0+0.3)+1*(0.5+0.5))/1.]
         ]) # n_batch x n_out
 
-        dw, dt, dd, dtheta = get_spiketime_derivative(delayed_input_spikes, input_weights, neuron_params, device, output_spikes, input_delays)
+        dw, dt, dd, dtheta = get_spiketime_derivative(delayed_input_spikes, input_weights, neuron_params, device, output_spikes, input_delays, thresholds)
         dw_solution = torch.tensor([
             [[(0.1-output_spikes[0,0])/4., (0.05-output_spikes[0,1])/4., (0.3-output_spikes[0,2])/1.], 
              [(0.1+0.01-output_spikes[0,0])/4., (0.1+0.2-output_spikes[0,1])/4., (0.1+0.5-output_spikes[0,2])/1.]],
@@ -267,7 +267,7 @@ class TestSpiketimeLinear(unittest.TestCase):
                 [(1+3*(0+0.1))/3., (2+1*(0+0.05)+3*(0.5+0.2))/4., (3+0*(0+0.3)+1*(0.5+0.5))/1.]
             ]) # n_batch x n_out
 
-            dw, dt, dd, dtheta = get_spiketime_derivative(delayed_input_spikes, input_weights, neuron_params, device, output_spikes, input_delays)
+            dw, dt, dd, dtheta = get_spiketime_derivative(delayed_input_spikes, input_weights, neuron_params, device, output_spikes, input_delays, thresholds)
             dw_solution = torch.tensor([
                 [[(0.1-output_spikes[0,0])/4., (0.05-output_spikes[0,1])/4., (0.3-output_spikes[0,2])/1.], 
                 [(0.1+0.01-output_spikes[0,0])/4., (0.1+0.2-output_spikes[0,1])/4., (0.1+0.5-output_spikes[0,2])/1.]],

--- a/src/utils_spiketime_dt.py
+++ b/src/utils_spiketime_dt.py
@@ -15,29 +15,28 @@ import torch.autograd
 import yaml
 
 
-def get_spiketime(input_spikes, input_weights, neuron_params, device):
+def get_spiketime(input_spikes, input_weights, thresholds, neuron_params, device):
     """Calculating spike times, all at once.
 
     Called from EqualtimeFunction below, for each layer.
     Dimensions are crucial:
-        input weights have dimension BATCHESxNxM with N pre and M postsynaptic neurons.
+        input weights and (delayed) input spikes have dimension BATCHESxNxM with N pre and M postsynaptic neurons, 
+        where the last coordinate represents the output neuron for which the input is considered
+        thresholds have dimension M, corresponding to all postsynaptic neurons
+    
+    The functions relies on the incoming spike time with their respective weights being sorted.
+
+    The return value (n_batch, n_presyn, n_postsyn) contains the time of on outgoing spike to neuron n_postsyn (for n_batch),
+    given that all input spikes up to the one at n_presyn have arrived.
     """
-    n_batch, n_presyn = input_spikes.shape
-    n_batch2, n_presyn2, n_postsyn = input_weights.shape
+    n_batch, n_presyn, n_postsyn = input_spikes.shape
+    n_batch2, n_presyn2, n_postsyn2 = input_weights.shape
+    n_postsyn3 = thresholds.shape[0]
     assert n_batch == n_batch2, "Deep problem with unequal batch sizes"
     assert n_presyn == n_presyn2
+    assert n_postsyn == n_postsyn2 == n_postsyn3
 
-    # split up weights for each causal set length
-    weights_split = input_weights[:, :, None, :]
-    weights_split = weights_split.repeat(1, 1, n_presyn, 1)
-    tmp_mask = torch.tril_indices(n_presyn, n_presyn, offset=-1)  # want diagonal thus offset
-    weights_split[:, tmp_mask[0], tmp_mask[1], :] = 0.
-
-    # temporary reshape for torch reasons
-    weights_split = weights_split.view(n_batch, n_presyn, n_presyn * n_postsyn)
-    # new (empty) dimension needed for torch reasons
-    input_spikes = input_spikes.view(n_batch, 1, n_presyn)
-
+    # fastest implementation: multiply spike times by weights and finally sum over causal spike times
     tau_syn = neuron_params['tau_syn']
     tau_mem = neuron_params['tau_mem']
     assert tau_syn / tau_mem == neuron_params['g_leak'], \
@@ -49,40 +48,39 @@ def get_spiketime(input_spikes, input_weights, neuron_params, device):
 
     # to prevent NaNs when first (sorted) weight(s) is 0, thus A and B, and ratio NaN add epsilon
     eps = 1e-6
-    factor_a1 = torch.matmul(exponentiated_spike_times_syn, weights_split) + eps
-    factor_a2 = torch.matmul(exponentiated_spike_times_mem, weights_split)
-    factor_c = (neuron_params['threshold'] - neuron_params['leak']) * neuron_params['g_leak']
+    factor_a1 = torch.cumsum(exponentiated_spike_times_syn*input_weights, dim=1) + eps # n_batch x n_presyn x postsyn
+    factor_a2 = torch.cumsum(exponentiated_spike_times_mem*input_weights, dim=1) + eps # also added eps here
+    factor_c = (thresholds.view(1, 1, n_postsyn) - neuron_params['leak']) * neuron_params['g_leak']
 
     factor_sqrt = torch.sqrt(factor_a2 ** 2 - 4 * factor_a1 * factor_c)
 
     ret_val = 2. * tau_syn * torch.log(2. * factor_a1 / (factor_a2 + factor_sqrt))
     ret_val[torch.isnan(ret_val)] = float('inf')
     
-    ret_val = ret_val.view(n_batch, n_presyn, n_postsyn)
-
     return ret_val
 
 
 def get_spiketime_derivative(input_spikes, input_weights, neuron_params, device,
-                             output_spikes):
+                             output_spikes, input_delays, thresholds):
     """Calculating the derivatives, see above.
 
-    Weights have shape batch,presyn,postsyn, are ordered according to spike times
+    Weights and (delayed) input spikes have shape batch,presyn,postsyn, are ordered according to spike times.
     """
-    n_batch, n_presyn = input_spikes.shape
-    n_batch2, n_presyn2, n_postsyn = input_weights.shape
-    assert n_batch == n_batch2, "Deep problem with unequal batch sizes"
-    assert n_presyn == n_presyn2
+    n_batch, n_presyn, n_postsyn = input_spikes.shape
+    n_batch2, n_presyn2, n_postsyn2 = input_weights.shape
+    n_batch3, n_postsyn3 = output_spikes.shape
+    n_presyn3, n_postsyn4 = input_delays.shape
+    assert n_batch == n_batch2 == n_batch3, "Deep problem with unequal batch sizes"
+    assert n_presyn == n_presyn2 == n_presyn3
+    assert n_postsyn == n_postsyn2 == n_postsyn3 == n_postsyn4
 
-    output_minus_input = -input_spikes.view(n_batch, n_presyn, 1) + output_spikes.view(n_batch, 1, n_postsyn)
+    output_minus_input = -input_spikes + output_spikes.view(n_batch, 1, n_postsyn)
     mask = (output_minus_input < 0) | torch.isinf(output_minus_input) | torch.isnan(output_minus_input)
     causal_weights = input_weights
     # set infinities to 0 preventing nans
     causal_weights[mask] = 0.
     input_spikes[torch.isinf(input_spikes)] = 0.
     output_spikes[torch.isinf(output_spikes)] = 0.
-
-    input_spikes = input_spikes.view(n_batch, 1, n_presyn)
 
     tau_syn = neuron_params['tau_syn']
     tau_mem = neuron_params['tau_mem']
@@ -91,15 +89,11 @@ def get_spiketime_derivative(input_spikes, input_weights, neuron_params, device,
     exponentiated_spike_times_out_mem = torch.exp(output_spikes / tau_mem)
 
     eps = 1e-6
-    factor_a1 = torch.matmul(exponentiated_spike_times_syn, causal_weights) + eps
-    factor_a2 = torch.matmul(exponentiated_spike_times_mem, causal_weights) + eps
-    factor_c = (neuron_params['threshold'] - neuron_params['leak']) * neuron_params['g_leak']
+    factor_a1 = torch.sum(exponentiated_spike_times_syn * causal_weights, dim=1, keepdim=True) + eps
+    factor_a2 = torch.sum(exponentiated_spike_times_mem * causal_weights, dim=1, keepdim=True) + eps
+    factor_c = (thresholds.view(1, 1, n_postsyn) - neuron_params['leak']) * neuron_params['g_leak']
 
     factor_sqrt = torch.sqrt(factor_a2 ** 2 - 4 * factor_a1 * factor_c)
-
-    exponentiated_spike_times_out_mem = exponentiated_spike_times_out_mem.squeeze().unsqueeze(1)
-    exponentiated_spike_times_syn = exponentiated_spike_times_syn.squeeze().unsqueeze(-1)
-    exponentiated_spike_times_mem = exponentiated_spike_times_mem.squeeze().unsqueeze(-1)
 
     dw = tau_mem * (((1. + factor_c / factor_sqrt * exponentiated_spike_times_out_mem)
                      / factor_a1 * exponentiated_spike_times_syn)
@@ -111,5 +105,7 @@ def get_spiketime_derivative(input_spikes, input_weights, neuron_params, device,
     # manually set the uncausal and inf output spike entries 0
     dw[mask] = 0.
     dt[mask] = 0.
+    dtheta = torch.zeros_like(dt)
+    dd = torch.zeros_like(dt)
 
-    return dw, dt
+    return dw, dt, dtheta, dd

--- a/src/utils_spiketime_linear.py
+++ b/src/utils_spiketime_linear.py
@@ -22,9 +22,10 @@ def get_spiketime(input_spikes, input_weights, thresholds, neuron_params, device
     """
     n_batch, n_presyn, n_postsyn = input_spikes.shape
     n_batch2, n_presyn2, n_postsyn2 = input_weights.shape
+    n_postsyn3 = thresholds.shape[0]
     assert n_batch == n_batch2, "Deep problem with unequal batch sizes"
     assert n_presyn == n_presyn2
-    assert n_postsyn == n_postsyn2
+    assert n_postsyn == n_postsyn2 == n_postsyn3
 
     # fastest implementation: multiply spike times by weights and finally sum over causal spike times
     # set positive lower bound to avoid NaN during division, since a negative (or 0) sum of weights means there is no output pulse
@@ -39,7 +40,7 @@ def get_spiketime(input_spikes, input_weights, thresholds, neuron_params, device
 
 
 def get_spiketime_derivative(input_spikes, input_weights, neuron_params, device,
-                             output_spikes, input_delays):
+                             output_spikes, input_delays, thresholds):
     """Calculating the derivatives, see above.
 
     Weights and (delayed) input spikes have shape batch,presyn,postsyn, are ordered according to spike times.


### PR DESCRIPTION
The spike time calculation for the new linear activation function and the alpha activation function can now be used interchangeably. We were able to speed up both (in particular the forward pass) by using a cumulative sum rather than summing over another expanded dimension. Due to this change, the bottleneck complexity is now the sorting of the (delayed) input spikes rather than the mere spike time computations.

This change also allows the use of custom delays and thresholds with the alpha activation function, however, since we haven't computed the respective gradients in this model, no training of the delay or threshold is provided.

